### PR TITLE
Support Docker for Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # determine platform
-ifeq (Boot2Docker, $(findstring Boot2Docker, $(shell docker info)))
+ifeq (Darwin, $(findstring Darwin, $(shell uname -a)))
   PLATFORM := OSX
 else
   PLATFORM := Linux


### PR DESCRIPTION
Changed detection method from 'docker info' to 'uname -a'

As the commit message suggests, this should allow to support [Docker for Mac](https://docs.docker.com/docker-for-mac/).

Don't hesitate to get back to me if this doesn't suit your needs and should be adapted.